### PR TITLE
Eliminate conflict between EscrowBot and SwapBot

### DIFF
--- a/swap.py
+++ b/swap.py
@@ -556,6 +556,9 @@ def main():
 	# This is for if anyone sends us a message requesting swap data
 	for message in messages:
 		text = (message.body + " " +  message.subject).replace("\n", " ").replace("\r", " ")
+		#Skip if first char is !. These messages potentially contain EscrowBot commands
+		if (text[0] == '!') :
+			continue
 		username = get_username_from_text(text)[2:]  # remove the leading u/ in the username
 		if not username:  # If we didn't find a username, let them know and continue
 			reply_text = "Hi there,\n\nYou did not specify a username to check. Please ensure that you have a user name in the body of the message you just sent me. Please feel free to try again. Thanks!"


### PR DESCRIPTION
Since EscrowBot and SwapBot use the same Reddit account on r/Cash4Cash (u/C4C_Bot), this means that, occasionally, the two scripts both reply to a message. A message that contains a valid EscrowBot command will be responded to by SwapBot, saying no username was provided.

Since all EscrowBot commands all begin with an exclamation point, this can be solved by simply checking if the first char of the message is an exclaimation point, and skipping it if yes.